### PR TITLE
商品出品機能の実装の修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   def index
     @items = Item.all.includes(:pictures).order('created_at DESC')
   end
-  
+
   def new
     if user_signed_in?
       @item = Item.new
@@ -15,10 +15,11 @@ class ItemsController < ApplicationController
 
   def create
     @item = Item.new(item_params)
-    if @item.save!
+    if @item.save
       redirect_to root_path
     else
-      render :new
+      @item.pictures.build
+      redirect_to new_item_path
     end
 
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,8 +10,11 @@ class Item < ApplicationRecord
   accepts_nested_attributes_for :brand, allow_destroy: true
   enum trading_status: { selling: 0, sold: 1 }
 
+  validates_associated :pictures
+  
   validates :name, presence: true, length: {maximum: 40}
   validates :explanation, presence: true, length: {maximum: 1000}
   validates :size, :category, :condition, :postage_payer, :shipping_origin, :days_to_ship, :trading_status, presence: true, exclusion: {in: ["選択してください"]}
   validates :price, presence: true, numericality: {greater_than: 299, less_than: 10000000}
+  validates :pictures, presence: true
 end

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -1,7 +1,7 @@
 class Picture < ApplicationRecord
   belongs_to :item
 
-  validates :image, :item, presence: true
+  validates :image, presence: true
 
   mount_uploader :image, ImageUploader
 end


### PR DESCRIPTION
# What
商品出品機能の実装の修正

# Why
下記内容の不具合と不要な箇所の修正のため。

・商品画像がなくても保存できてしまう不具合があったため、itemモデルにpicturesのバリデーションを追記して修正。
・pictureモデルのitemのpresence: trueのバリデーションは外部参照カラムのため削除。
・itemsコントローラのcreate内のsaveについて、！をつけていると保存に失敗した時に例外（エラー）が発生するため、！を削除し、falseが返るようにする。
・render :newだと保存に失敗した際に戻ったビューのURLがlocalhost:3000/items/newではなく、localhost:3000/itemsとなって、かつ画像選択ができなくなってしまうため、@item.pictures.buildで再度buildし、redirect_to new_item_pathでURLの不具合の解消を実施。

上記修正で出品機能で必要な実装は完了と考えております。