### PR TITLE
Item delete

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,6 +28,12 @@ class ItemsController < ApplicationController
     @user = @item.seller
   end
 
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
+  end
+
 private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,11 +31,13 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    item = Item.find(params[:id])
-    item.destroy
-    redirect_to root_path
+    @item = Item.find(params[:id])
+    if @item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
   end
-
 private
 
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,7 +5,6 @@ class Item < ApplicationRecord
   belongs_to :brand, optional: true
   has_many :comments, dependent: :destroy
   has_many :pictures, dependent: :destroy
-  has_many :likes, dependent: :destroy
   accepts_nested_attributes_for :pictures, allow_destroy: true
   accepts_nested_attributes_for :brand, allow_destroy: true
   enum trading_status: { selling: 0, sold: 1 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,6 @@ class User < ApplicationRecord
   has_one :deliver_address, dependent: :destroy
   has_many :items, dependent: :destroy
   has_many :comments, dependent: :destroy
-  has_many :likes, dependent: :destroy
   has_many :buy_items, class_name: 'Transaction', :foreign_key => 'buyer_id'
   has_many :sell_items, class_name: 'Transaction', :foreign_key => 'seller_id'
   

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -183,7 +183,7 @@
                 = link_to "#", class: "edit" do
                   編集
               %ul.delete
-                = link_to "#", class: "delete" do
+                = link_to item_path(@item.id), method: :delete, class: "delete" do
                   削除
           - elsif user_signed_in?
             .item__box__buy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   end
 
   root "items#index"
-  resources :items, only: [:new, :create, :show]
+  resources :items, only: [:new, :create, :show, :destroy]
   resources :puroducts, onyl: [:index]
 end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_10_062100) do
+ActiveRecord::Schema.define(version: 2020_05_13_203116) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture_id"
@@ -28,6 +28,14 @@ ActiveRecord::Schema.define(version: 2020_05_10_062100) do
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "ancestry"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "item_id"
+    t.text "text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
#What
商品削除機能実装
destroyのルーティング追記
コントローラーにdestroyアクションの追記
商品詳細ページから削除ボタンで商品を削除することができる。
出品者のみ削除できる。

#Why
商品の販売を取り消したい場合に削除機能が必要だから。
出品者以外が削除できるとアプリとして問題になるから。

https://gyazo.com/0ed8ed65a836c312357bf4f792ef918f

https://gyazo.com/85ddd5f079400ed2347fd96334119702

https://gyazo.com/95a6efa0a6441efdd5de080cccc84aa3

https://gyazo.com/76739818f6de52aa92c85e6aa8d5398d